### PR TITLE
Fix compatibility with Node.js 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,3 @@ node_js:
   - "6"
   - "8"
   - "10"
-matrix:
-  allow_failures:
-    - node_js: "10"

--- a/index.js
+++ b/index.js
@@ -27,7 +27,9 @@ module.exports = function setHeader(res, name, value) {
   //
   res.setHeader(name, value);
 
-  var symbols = (typeof Object.getOwnPropertySymbols == "function" ? Object.getOwnPropertySymbols(res) : []);
+  var symbols = Object.getOwnPropertySymbols
+    ? Object.getOwnPropertySymbols(res)
+    : [];
   var symbol;
 
   if (symbols.length) {
@@ -38,7 +40,7 @@ module.exports = function setHeader(res, name, value) {
       }
     }
   } else {
-    symbol = "_headers";
+    symbol = '_headers';
   }
 
   //
@@ -64,7 +66,7 @@ module.exports = function setHeader(res, name, value) {
     // Return the value that got set using our `setHeader` method.
     //
     get: function get() {
-      return (symbols.length == 1 ? [ key, value ] : value);
+      return typeof symbol === 'symbol' ? [key, value] : value;
     },
 
     //


### PR DESCRIPTION
The [`symbols.length == 1`](https://github.com/3rd-Eden/setHeader/blob/687d30101d156408a250d0a81bc45069e67a0279/index.js#L67) check fails in the getter as `Object.getOwnPropertySymbols(res)` return multiple symbols on Node.js 10.